### PR TITLE
Get everything up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,13 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   g8Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v5
+      - uses: actions/checkout@v2
+      - uses: olafurpg/setup-java@v2
       - name: g8Test
         run: sbt g8Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-java@v2
+      - uses: actions/setup-java@v2
       - name: g8Test
         run: sbt g8Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.0-M1")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")
 libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }

--- a/src/main/g8/.mill-version
+++ b/src/main/g8/.mill-version
@@ -1,0 +1,1 @@
+$mill_version$

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,3 +3,4 @@ moduleName=$name;format="space,Camel"$
 description=A minimal Scala project using the Mill build tool.
 scala_version=maven(org.scala-lang, scala-compiler, stable)
 munit_version=maven(org.scalameta, munit_2.13, stable)
+mill_version=maven(com.lihaoyi, mill-scalalib-api_2.13)

--- a/src/main/g8/mill
+++ b/src/main/g8/mill
@@ -1,0 +1,136 @@
+#!/usr/bin/env sh
+
+# This is a wrapper script, that automatically download mill from GitHub release pages
+# You can give the required mill version with --mill-version parameter
+# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+#
+# Project page: https://github.com/lefou/millw
+# Script Version: 0.3.9
+#
+# If you want to improve this script, please also contribute your changes back!
+#
+# Licensed under the Apache License, Version 2.0
+
+
+DEFAULT_MILL_VERSION=0.9.10
+
+set -e
+
+MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
+
+if [ "x\${CURL_CMD}" = "x" ] ; then
+  CURL_CMD=curl
+fi
+
+# Explicit commandline argument takes precedence over all other methods
+if [ "x\$1" = "x--mill-version" ] ; then
+  shift
+  if [ "x\$1" != "x" ] ; then
+    MILL_VERSION="\$1"
+    shift
+  else
+    echo "You specified --mill-version without a version." 1>&2
+    echo "Please provide a version that matches one provided on" 1>&2
+    echo "\${MILL_REPO_URL}/releases" 1>&2
+    false
+  fi
+fi
+
+# Please note, that if a MILL_VERSION is already set in the environment,
+# We reuse it's value and skip searching for a value.
+
+# If not already set, read .mill-version file
+if [ "x\${MILL_VERSION}" = "x" ] ; then
+  if [ -f ".mill-version" ] ; then
+    MILL_VERSION="\$(head -n 1 .mill-version 2> /dev/null)"
+  fi
+fi
+
+if [ "x\${XDG_CACHE_HOME}" != "x" ] ; then
+  MILL_DOWNLOAD_PATH="\${XDG_CACHE_HOME}/mill/download"
+else
+  MILL_DOWNLOAD_PATH="\${HOME}/.cache/mill/download"
+fi
+
+# If not already set, try to fetch newest from Github
+if [ "x\${MILL_VERSION}" = "x" ] ; then
+  # TODO: try to load latest version from release page
+  echo "No mill version specified." 1>&2
+  echo "You should provide a version via '.mill-version' file or --mill-version option." 1>&2
+
+  mkdir -p "\${MILL_DOWNLOAD_PATH}"
+  LANG=C touch -d '1 hour ago' "\${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
+    # we might be on OSX or BSD which don't have -d option for touch
+    # but probably a -A [-][[hh]mm]SS
+    touch "\${MILL_DOWNLOAD_PATH}/.expire_latest"; touch -A -010000 "\${MILL_DOWNLOAD_PATH}/.expire_latest"
+  ) || (
+    # in case we still failed, we retry the first touch command with the intention
+    # to show the (previously suppressed) error message
+    LANG=C touch -d '1 hour ago' "\${MILL_DOWNLOAD_PATH}/.expire_latest"
+  )
+  
+  if [ "\${MILL_DOWNLOAD_PATH}/.latest" -nt "\${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
+    # we know a current latest version
+    MILL_VERSION="\$(head -n 1 \${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
+  fi
+
+  if [ "x\${MILL_VERSION}" = "x" ] ; then
+    # we don't know a current latest version
+    echo "Retrieving latest mill version ..." 1>&2
+    LANG=C \${CURL_CMD} -s -i -f -I \${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "\${MILL_DOWNLOAD_PATH}/.latest"
+    MILL_VERSION="\$(head -n 1 \${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
+  fi
+
+  if [ "x\${MILL_VERSION}" = "x" ] ; then
+    # Last resort
+    MILL_VERSION="\${DEFAULT_MILL_VERSION}"
+    echo "Falling back to hardcoded mill version \${MILL_VERSION}" 1>&2
+  else
+    echo "Using mill version \${MILL_VERSION}" 1>&2
+  fi
+fi
+
+MILL="\${MILL_DOWNLOAD_PATH}/\${MILL_VERSION}"
+
+# If not already downloaded, download it
+if [ ! -s "\${MILL}" ] ; then
+  
+  # support old non-XDG download dir
+  MILL_OLD_DOWNLOAD_PATH="\${HOME}/.mill/download"
+  OLD_MILL="\${MILL_OLD_DOWNLOAD_PATH}/\${MILL_VERSION}"
+  if [ -x "\${OLD_MILL}" ] ; then
+    MILL="\${OLD_MILL}"
+  else
+    VERSION_PREFIX="\$(echo -n \$MILL_VERSION | cut -b -4)"
+    case \$VERSION_PREFIX in
+      0.0. | 0.1. | 0.2. | 0.3. | 0.4. )
+        DOWNLOAD_SUFFIX=""
+        ;;
+      *)
+        DOWNLOAD_SUFFIX="-assembly"
+        ;;
+    esac
+    unset VERSION_PREFIX
+
+    DOWNLOAD_FILE=\$(mktemp mill.XXXXXX)
+    # TODO: handle command not found
+    echo "Downloading mill \${MILL_VERSION} from \${MILL_REPO_URL}/releases ..." 1>&2
+    MILL_VERSION_TAG=\$(echo \$MILL_VERSION | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+    \${CURL_CMD} -L -o "\${DOWNLOAD_FILE}" "\${MILL_REPO_URL}/releases/download/\${MILL_VERSION_TAG}/\${MILL_VERSION}\${DOWNLOAD_SUFFIX}"
+    chmod +x "\${DOWNLOAD_FILE}"
+    mkdir -p "\${MILL_DOWNLOAD_PATH}"
+    mv "\${DOWNLOAD_FILE}" "\${MILL}"
+
+    unset DOWNLOAD_FILE
+    unset DOWNLOAD_SUFFIX
+  fi
+fi
+
+unset MILL_DOWNLOAD_PATH
+unset MILL_OLD_DOWNLOAD_PATH
+unset OLD_MILL
+unset MILL_VERSION
+unset MILL_VERSION_TAG
+unset MILL_REPO_URL
+
+exec \$MILL "\$@"

--- a/src/main/g8/mill.bat
+++ b/src/main/g8/mill.bat
@@ -1,0 +1,115 @@
+@echo off
+
+rem This is a wrapper script, that automatically download mill from GitHub release pages
+rem You can give the required mill version with --mill-version parameter
+rem If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
+rem
+rem Project page: https://github.com/lefou/millw
+rem Script Version: 0.3.9
+rem
+rem If you want to improve this script, please also contribute your changes back!
+rem
+rem Licensed under the Apache License, Version 2.0
+
+rem setlocal seems to be unavailable on Windows 95/98/ME
+rem but I don't think we need to support them in 2019
+setlocal enabledelayedexpansion
+
+set "DEFAULT_MILL_VERSION=0.9.10"
+
+set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
+
+rem %~1% removes surrounding quotes
+if [%~1%]==[--mill-version] (
+    rem shift command doesn't work within parentheses
+    if not [%~2%]==[] (
+        set MILL_VERSION=%~2%
+        set "STRIP_VERSION_PARAMS=true"
+    ) else (
+        echo You specified --mill-version without a version. 1>&2
+        echo Please provide a version that matches one provided on 1>&2
+        echo %MILL_REPO_URL%/releases 1>&2
+        exit /b 1
+    )
+)
+
+if [!MILL_VERSION!]==[] (
+  if exist .mill-version (
+      set /p MILL_VERSION=<.mill-version
+  )
+)
+
+if [!MILL_VERSION!]==[] (
+    set MILL_VERSION=%DEFAULT_MILL_VERSION%
+)
+
+set MILL_DOWNLOAD_PATH=%USERPROFILE%\.mill\download
+
+rem without bat file extension, cmd doesn't seem to be able to run it
+set MILL=%MILL_DOWNLOAD_PATH%\!MILL_VERSION!.bat
+
+if not exist "%MILL%" (
+    set VERSION_PREFIX=%MILL_VERSION:~0,4%
+    set DOWNLOAD_SUFFIX=-assembly
+    if [!VERSION_PREFIX!]==[0.0.] set DOWNLOAD_SUFFIX=
+    if [!VERSION_PREFIX!]==[0.1.] set DOWNLOAD_SUFFIX=
+    if [!VERSION_PREFIX!]==[0.2.] set DOWNLOAD_SUFFIX=
+    if [!VERSION_PREFIX!]==[0.3.] set DOWNLOAD_SUFFIX=
+    if [!VERSION_PREFIX!]==[0.4.] set DOWNLOAD_SUFFIX=
+    set VERSION_PREFIX=
+
+    for /F "delims=- tokens=1" %%A in ("!MILL_VERSION!") do set MILL_VERSION_BASE=%%A
+    for /F "delims=- tokens=2" %%A in ("!MILL_VERSION!") do set MILL_VERSION_MILESTONE=%%A
+	set VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
+    if [!VERSION_MILESTONE_START!]==[M] (
+        set MILL_VERSION_TAG="!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!"
+    ) else (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!
+    )
+
+    rem there seems to be no way to generate a unique temporary file path (on native Windows)
+    set DOWNLOAD_FILE=%MILL%.tmp
+
+    set DOWNLOAD_URL=%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!DOWNLOAD_SUFFIX!
+
+    echo Downloading mill %MILL_VERSION% from %MILL_REPO_URL%/releases ... 1>&2
+
+    if not exist "%MILL_DOWNLOAD_PATH%" mkdir "%MILL_DOWNLOAD_PATH%"
+    rem curl is bundled with recent Windows 10
+    rem but I don't think we can expect all the users to have it in 2019
+    where /Q curl
+    if %ERRORLEVEL% EQU 0 (
+        curl -L "!DOWNLOAD_URL!" -o "!DOWNLOAD_FILE!"
+    ) else (
+        rem bitsadmin seems to be available on Windows 7
+        rem without /dynamic, github returns 403
+        rem bitsadmin is sometimes needlessly slow but it looks better with /priority foreground
+        bitsadmin /transfer millDownloadJob /dynamic /priority foreground "!DOWNLOAD_URL!" "!DOWNLOAD_FILE!"
+    )
+    if not exist "!DOWNLOAD_FILE!" (
+        echo Could not download mill %MILL_VERSION% 1>&2
+        exit /b 1
+    )
+
+    move /y "!DOWNLOAD_FILE!" "%MILL%"
+
+    set DOWNLOAD_FILE=
+    set DOWNLOAD_SUFFIX=
+)
+
+set MILL_DOWNLOAD_PATH=
+set MILL_VERSION=
+set MILL_REPO_URL=
+
+set MILL_PARAMS=%*
+
+if defined STRIP_VERSION_PARAMS (
+    for /f "tokens=1-2*" %%a in ("%*") do (
+        rem strip %%a - It's the "--mill-version" option.
+        rem strip %%b - it's the version number that comes after the option.
+        rem keep  %%c - It's the remaining options.
+        set MILL_PARAMS=%%c
+    )
+)
+
+"%MILL%" %MILL_PARAMS%


### PR DESCRIPTION
This updates and adds a few different things:

- sbt version
- g8 version of the plugin
- adds in mill and millw which is normally expected
- adds in a .mill-version to avoid the warning
- Updates ci
- dependabot to keep actions up to date